### PR TITLE
GH1: Add option to specify version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
     steps:
       - name: Get the sources
         uses: actions/checkout@v1
@@ -18,6 +21,7 @@ jobs:
       - name: Run the tests with code coverage
         run: npm run test
       - name: Upload the code coverage report to Coveralls
+        if: github.event_name != 'pull_request'
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - master
 jobs:
-  build:
-    name: Test
+  testTarget:
+    name: Test specific target
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -14,8 +14,30 @@ jobs:
     steps:
       - name: Get the sources
         uses: actions/checkout@v1
+      - name: Restore the dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
       - name: Run a Cake script with a specific target
         uses: ./
         with:
           script-path: build.cake
           target: Successful-Task
+  testVersion:
+    name: Test specific version
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    steps:
+      - name: Get the sources
+        uses: actions/checkout@v1
+      - name: Restore the dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Run specific a version of Cake 
+        uses: ./
+        with:
+          cake-version: 0.34.1
+          target: Version-Check-Task

--- a/__tests__/cake.test.ts
+++ b/__tests__/cake.test.ts
@@ -4,6 +4,10 @@ import { CakeTool } from '../src/cake';
 import { ToolsDirectory } from '../src/toolsDirectory';
 import { CakeArgument, CakeSwitch } from '../src/cakeParameter';
 
+const isRunningOnWindows = (require('os').platform() === 'win32');
+const pathToLocalToolsDirectory = isRunningOnWindows ? 'path\\to\\tool' : 'path/to/tool';
+const pathToLocalTool = isRunningOnWindows ? 'path\\to\\tool\\dotnet-cake' : 'path/to/tool/dotnet-cake';
+
 jest.mock('@actions/exec');
 jest.mock('@actions/io');
 
@@ -57,34 +61,34 @@ describe('When running a script successfully using the local Cake tool', () => {
   });
 
   test('it should run the local dotnet-cake tool on the default script', async () => {
-    await CakeTool.runScript(undefined, new ToolsDirectory('path/to/tool'));
-    expect(fakeExec).toBeCalledWith('path/to/tool/dotnet-cake', ['build.cake']);
+    await CakeTool.runScript(undefined, new ToolsDirectory(pathToLocalToolsDirectory));
+    expect(fakeExec).toBeCalledWith(pathToLocalTool, ['build.cake']);
   });
 
   test('it should run the local dotnet-cake tool on the specified script', async () => {
-    await CakeTool.runScript('script.cake', new ToolsDirectory('path/to/tool'));
-    expect(fakeExec).toBeCalledWith('path/to/tool/dotnet-cake', ['script.cake']);
+    await CakeTool.runScript('script.cake', new ToolsDirectory(pathToLocalToolsDirectory));
+    expect(fakeExec).toBeCalledWith(pathToLocalTool, ['script.cake']);
   });
 
   test('it should run the local dotnet-cake tool with the specified parameters', async () => {
     await CakeTool.runScript(
       'script.cake',
-      new ToolsDirectory('path/to/tool'),
+      new ToolsDirectory(pathToLocalToolsDirectory),
       new CakeArgument('param', 'arg'),
       new CakeSwitch('switch'));
     expect(fakeExec).toBeCalledWith(
-      'path/to/tool/dotnet-cake',
+      pathToLocalTool,
       ['script.cake', '--param=arg', '--switch']);
   });
 
   test('it should run the local dotnet-cake tool without any invalid parameters', async () => {
     await CakeTool.runScript(
       'script.cake',
-      new ToolsDirectory('path/to/tool'),
+      new ToolsDirectory(pathToLocalToolsDirectory),
       new CakeArgument('', ''),
       new CakeSwitch('switch'));
     expect(fakeExec).toBeCalledWith(
-      'path/to/tool/dotnet-cake',
+      pathToLocalTool,
       ['script.cake', '--switch']);
   });
 });

--- a/__tests__/dotnet.test.ts
+++ b/__tests__/dotnet.test.ts
@@ -3,6 +3,9 @@ import { exec } from '@actions/exec';
 import { DotNet } from '../src/dotnet';
 import { ToolsDirectory } from '../src/toolsDirectory';
 
+const isRunningOnWindows = (require('os').platform() === 'win32');
+const targetDirectory = isRunningOnWindows ? 'target\\directory' : 'target/directory';
+
 jest.mock('@actions/core');
 jest.mock('@actions/exec');
 
@@ -28,8 +31,8 @@ describe('When successfully installing the Cake Tool locally', () => {
   });
 
   test('it should install the Cake.Tool in the specified target directory', async () => {
-    await DotNet.installLocalCakeTool(new ToolsDirectory('target/directory'));
-    expect(fakeExec).toBeCalledWith('dotnet tool install', ['--tool-path', 'target/directory', 'Cake.Tool']);
+    await DotNet.installLocalCakeTool(new ToolsDirectory(targetDirectory));
+    expect(fakeExec).toBeCalledWith('dotnet tool install', ['--tool-path', targetDirectory, 'Cake.Tool']);
   });
 });
 
@@ -62,8 +65,8 @@ describe('When successfully installing a tool locally', () => {
   });
 
   test('it should install the specified tool in the specified target directory', async () => {
-    await DotNet.installLocalTool('The.Tool', new ToolsDirectory('target/directory'));
-    expect(fakeExec).toBeCalledWith('dotnet tool install', ['--tool-path', 'target/directory', 'The.Tool']);
+    await DotNet.installLocalTool('The.Tool', new ToolsDirectory(targetDirectory));
+    expect(fakeExec).toBeCalledWith('dotnet tool install', ['--tool-path', targetDirectory, 'The.Tool']);
   });
 });
 

--- a/__tests__/dotnet.test.ts
+++ b/__tests__/dotnet.test.ts
@@ -34,6 +34,12 @@ describe('When successfully installing the Cake Tool locally', () => {
     await DotNet.installLocalCakeTool(new ToolsDirectory(targetDirectory));
     expect(fakeExec).toBeCalledWith('dotnet tool install', ['--tool-path', targetDirectory, 'Cake.Tool']);
   });
+
+  test('it should install specified version of the Cake.Tool', async () => {
+    const cakeVersion = '0.35.0';
+    await DotNet.installLocalCakeTool(new ToolsDirectory(targetDirectory), cakeVersion);
+    expect(fakeExec).toBeCalledWith('dotnet tool install', ['--version', cakeVersion, '--tool-path', targetDirectory, 'Cake.Tool']);
+  });
 });
 
 describe('When failing to install the Cake Tool locally', () => {

--- a/__tests__/toolsDirectory.test.ts
+++ b/__tests__/toolsDirectory.test.ts
@@ -1,6 +1,8 @@
 import * as io from '@actions/io';
 import { ToolsDirectory } from '../src/toolsDirectory';
 
+const isRunningOnWindows = (require('os').platform() === 'win32');
+
 jest.mock('@actions/io');
 
 describe('When constructing the tools directory', () => {
@@ -21,12 +23,12 @@ describe('When constructing the tools directory', () => {
 
   test('it should keep ../ at the beginning of the specified path', () => {
     const sut = new ToolsDirectory('../theName');
-    expect(sut.path).toBe('../theName');
+    expect(sut.path).toBe(isRunningOnWindows ? '..\\theName' : '../theName');
   });
 
   test('it should remove double slashes from the specified path', () => {
     const sut = new ToolsDirectory('the//name');
-    expect(sut.path).toBe('the/name');
+    expect(sut.path).toBe(isRunningOnWindows ? 'the\\name' : 'the/name');
   });
 });
 
@@ -43,12 +45,12 @@ describe('When creating the directory on the file system', () => {
 describe('When appending a file name', () => {
   test('it should join the directory path with the specified file name', () => {
     const sut = new ToolsDirectory();
-    expect(sut.appendFileName('theFileName')).toBe(`${sut.path}/theFileName`);
+    expect(sut.appendFileName('theFileName')).toBe(`${sut.path}${isRunningOnWindows ? '\\' : '/'}theFileName`);
   });
 
   test('it should remove any extra slashes in front of the specified file name', () => {
     const sut = new ToolsDirectory();
-    expect(sut.appendFileName('/theFileName')).toBe(`${sut.path}/theFileName`);
+    expect(sut.appendFileName('/theFileName')).toBe(`${sut.path}${isRunningOnWindows ? '\\' : '/'}theFileName`);
   });
 });
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ branding:
   icon: 'package'
   color: 'yellow'
 inputs:
+  cake-version:
+    description: 'The version of the Cake to install.'
+    required: false
   script-path:
     description: 'The path of the Cake script to run.'
     required: false

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,9 @@
 var target = Argument("Target", "Successful-Task");
 
+Setup(context => {
+    Information("Executing using Cake {0}", context.Environment.Runtime.CakeVersion);
+});
+
 Task("Successful-Task")
     .Does(() =>
 {
@@ -10,6 +14,17 @@ Task("Failing-Task")
     .Does(() =>
 {
     throw new Exception("Failed");
+});
+
+Task("Version-Check-Task")
+    .Does(context =>
+{
+    var expect = new Version(0, 34, 1, 0);
+    if (expect != context.Environment.Runtime.CakeVersion)
+    {
+        throw new Exception($"Expected version {expect} got {context.Environment.Runtime.CakeVersion}");
+    }
+    Information("Successful");
 });
 
 RunTarget(target);

--- a/lib/dotnet.js
+++ b/lib/dotnet.js
@@ -23,14 +23,18 @@ class DotNet {
     static disableTelemetry() {
         core.exportVariable('DOTNET_CLI_TELEMETRY_OPTOUT', '1');
     }
-    static installLocalCakeTool(targetDirectory = new toolsDirectory_1.ToolsDirectory()) {
+    static installLocalCakeTool(targetDirectory = new toolsDirectory_1.ToolsDirectory(), version) {
         return __awaiter(this, void 0, void 0, function* () {
-            return DotNet.installLocalTool('Cake.Tool', targetDirectory);
+            return DotNet.installLocalTool('Cake.Tool', targetDirectory, version);
         });
     }
-    static installLocalTool(toolName, targetDirectory = new toolsDirectory_1.ToolsDirectory()) {
+    static installLocalTool(toolName, targetDirectory = new toolsDirectory_1.ToolsDirectory(), version) {
         return __awaiter(this, void 0, void 0, function* () {
-            const exitCode = yield exec_1.exec(dotnetToolInstall, ['--tool-path', targetDirectory.path, toolName]);
+            let parameters = ['--tool-path', targetDirectory.path, toolName];
+            if (version != undefined && version != '') {
+                parameters = ['--version', version].concat(parameters);
+            }
+            const exitCode = yield exec_1.exec(dotnetToolInstall, parameters);
             if (exitCode != 0) {
                 throw new Error(`Failed to install ${toolName}. Exit code: ${exitCode}`);
             }

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,12 +23,13 @@ const cakeParameter_1 = require("./cakeParameter");
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            const cakeVersion = core.getInput('cake-version');
             const scriptPath = core.getInput('script-path');
             const target = new cakeParameter_1.CakeArgument('target', core.getInput('target'));
             const toolsDir = new toolsDirectory_1.ToolsDirectory();
             yield toolsDir.create();
             dotnet_1.DotNet.disableTelemetry();
-            yield dotnet_1.DotNet.installLocalCakeTool(toolsDir);
+            yield dotnet_1.DotNet.installLocalCakeTool(toolsDir, cakeVersion);
             yield cake_1.CakeTool.runScript(scriptPath, toolsDir, target);
         }
         catch (error) {

--- a/src/dotnet.ts
+++ b/src/dotnet.ts
@@ -9,12 +9,19 @@ export class DotNet {
     core.exportVariable('DOTNET_CLI_TELEMETRY_OPTOUT', '1');
   }
 
-  static async installLocalCakeTool(targetDirectory: ToolsDirectory = new ToolsDirectory()) {
-    return DotNet.installLocalTool('Cake.Tool', targetDirectory);
+  static async installLocalCakeTool(targetDirectory: ToolsDirectory = new ToolsDirectory(), version?: string) {
+    return DotNet.installLocalTool('Cake.Tool', targetDirectory, version);
   }
 
-  static async installLocalTool(toolName: string, targetDirectory: ToolsDirectory = new ToolsDirectory()) {
-    const exitCode = await exec(dotnetToolInstall, ['--tool-path', targetDirectory.path, toolName]);
+  static async installLocalTool(toolName: string, targetDirectory: ToolsDirectory = new ToolsDirectory(), version?: string) {
+    let parameters = ['--tool-path', targetDirectory.path, toolName];
+    
+    if(version != undefined && version != '')
+    {
+      parameters = ['--version', version].concat(parameters);
+    }
+    
+    const exitCode = await exec(dotnetToolInstall, parameters);
 
     if (exitCode != 0) {
       throw new Error(`Failed to install ${toolName}. Exit code: ${exitCode}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { CakeArgument } from './cakeParameter';
 
 export async function run() {
   try {
+    const cakeVersion = core.getInput('cake-version');
     const scriptPath = core.getInput('script-path');
     const target = new CakeArgument('target', core.getInput('target'));
 
@@ -14,7 +15,7 @@ export async function run() {
 
     DotNet.disableTelemetry();
 
-    await DotNet.installLocalCakeTool(toolsDir);
+    await DotNet.installLocalCakeTool(toolsDir, cakeVersion);
     await CakeTool.runScript(scriptPath, toolsDir, target);
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
This PR addresses #1, by adding support for specifying / pinning the version of Cake installed using `cake-version` property, example: 
```yaml
    uses: ecampidoglio/cake-action@master
    with:
      cake-version: 0.34.1
      target: Version-Check-Task
```

This PR adds a bit more, please let me know if you want separate PRs/more focused PR, have separated in multiple commits though. 

* Adjusted tests to support Windows path if running on Windows
* Execute tests on both Windows and Linux
* Build addin for integration tests (otherwise previous built version is used)
* Add unit and integration tests for `cake-version`
* Only do coveralls if not PR i.e. running on master branch (build fails on PR / forks otherwise)


