### PR TITLE
GH3: Add Cake bootstrap support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,3 +36,10 @@ jobs:
         with:
           cake-version: 0.33.0
           target: Version-Check-Task
+      - name: Run bootstrapping of Cake module
+        uses: ./
+        with:
+          cake-bootstrap: true
+          script-path: module.cake
+
+

--- a/__tests__/cake.test.ts
+++ b/__tests__/cake.test.ts
@@ -118,3 +118,33 @@ describe('When failing to run a script using the local Cake tool', () => {
     await expect(CakeTool.runScript('script.cake', new ToolsDirectory())).rejects.toThrowError('-21');
   });
 });
+
+describe('When bootstrapping a script successfully using the local Cake tool', () => {
+  const fakeExec = exec as jest.MockedFunction<typeof exec>;
+
+  beforeAll(async () => {
+    fakeExec.mockReturnValue(Promise.resolve(0));
+  });
+
+  test('it should run the local dotnet-cake tool on the default script', async () => {
+    await CakeTool.bootstrapScript(undefined, new ToolsDirectory(pathToLocalToolsDirectory));
+    expect(fakeExec).toBeCalledWith(pathToLocalTool, ['build.cake', '--bootstrap']);
+  });
+
+  test('it should run the local dotnet-cake tool on the specified script', async () => {
+    await CakeTool.bootstrapScript('script.cake', new ToolsDirectory(pathToLocalToolsDirectory));
+    expect(fakeExec).toBeCalledWith(pathToLocalTool, ['script.cake', '--bootstrap']);
+  });
+});
+
+describe('When failing to bootstrap a script using the local Cake tool', () => {
+  const fakeExec = exec as jest.MockedFunction<typeof exec>;
+
+  beforeAll(() => {
+    fakeExec.mockReturnValue(Promise.resolve(-21));
+  });
+
+  test('it should throw an error containing the exit code', async () => {
+    await expect(CakeTool.bootstrapScript('script.cake', new ToolsDirectory())).rejects.toThrowError('-21');
+  });
+});

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -95,3 +95,44 @@ describe('When the script fails to run', () => {
     expect(fakeSetFailed).toBeCalledWith('the error message');
   });
 });
+
+describe('When running the action with the cake-bootstrap input argument', () => {
+  const fakeGetInput = core.getInput as jest.MockedFunction<typeof core.getInput>;
+  const fakeCakeTool = CakeTool as jest.MockedClass<typeof CakeTool>;
+
+  test('it should bootstrap the default Cake script', async () => {
+    fakeGetInput.mockImplementation(
+      key => {
+        switch (key) {
+          case 'cake-bootstrap':
+            return 'true';
+          default:
+            return '';
+        }
+      }
+    );
+    await run();
+    expect(fakeGetInput).toBeCalledWith('cake-bootstrap');
+    expect(fakeCakeTool.bootstrapScript).toBeCalled();
+  });
+
+  test('it should bootstrap the specified Cake script', async () => {
+    fakeGetInput.mockImplementation(
+      key => {
+        switch (key) {
+          case 'cake-bootstrap':
+            return 'true';
+          case 'script-path':
+            return 'custom.cake';
+          default:
+            return '';
+        }
+      }
+    );
+    await run();
+    expect(fakeGetInput).toBeCalledWith('cake-bootstrap');
+    expect(fakeCakeTool.bootstrapScript).toBeCalledWith(
+      'custom.cake',
+      expect.anything());
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
   cake-version:
     description: 'The version of Cake to install.'
     required: false
+  cake-bootstrap:
+    description: 'Flag for if Cake modules should be installed/bootstrapped.'
+    required: false
+    default: 'false'
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/lib/cake.js
+++ b/lib/cake.js
@@ -23,6 +23,15 @@ class CakeTool {
             }
         });
     }
+    static bootstrapScript(scriptPath = 'build.cake', workingDirectory) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const cakeToolPath = yield CakeTool.resolveCakeToolPath(workingDirectory);
+            const exitCode = yield exec_1.exec(cakeToolPath, [scriptPath, '--bootstrap']);
+            if (exitCode != 0) {
+                throw new Error(`Failed to bootstrap the build script. Exit code: ${exitCode}`);
+            }
+        });
+    }
     static resolveCakeToolPath(workingDirectory) {
         return __awaiter(this, void 0, void 0, function* () {
             return workingDirectory

--- a/lib/main.js
+++ b/lib/main.js
@@ -26,10 +26,14 @@ function run() {
             const scriptPath = core.getInput('script-path');
             const version = core.getInput('cake-version');
             const target = new cakeParameter_1.CakeArgument('target', core.getInput('target'));
+            const cakeBootstrap = (core.getInput('cake-bootstrap') || '').toLowerCase() === 'true';
             const toolsDir = new toolsDirectory_1.ToolsDirectory();
             toolsDir.create();
             dotnet_1.DotNet.disableTelemetry();
             yield dotnet_1.DotNet.installLocalCakeTool(toolsDir, version);
+            if (cakeBootstrap) {
+                yield cake_1.CakeTool.bootstrapScript(scriptPath, toolsDir);
+            }
             yield cake_1.CakeTool.runScript(scriptPath, toolsDir, target);
         }
         catch (error) {

--- a/module.cake
+++ b/module.cake
@@ -1,0 +1,16 @@
+// Install modules
+#module nuget:?package=Cake.DotNetTool.Module&version=0.3.1
+
+// Install .NET Core Global tools
+#tool "dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=5.0.1"
+
+Task("GitVersion")
+    .Does(() => {
+    Information("Calculating Semantic Version");
+
+    var assertedVersions = GitVersion();
+
+    Information("Calculated Semantic Version: {0}", assertedVersions.LegacySemVerPadded);
+});
+
+RunTarget("GitVersion");

--- a/src/cake.ts
+++ b/src/cake.ts
@@ -22,6 +22,18 @@ export class CakeTool {
     }
   }
 
+  static async bootstrapScript(
+    scriptPath: string = 'build.cake',
+    workingDirectory?: ToolsDirectory
+    ) {
+    const cakeToolPath = await CakeTool.resolveCakeToolPath(workingDirectory);
+    const exitCode = await exec(cakeToolPath, [scriptPath, '--bootstrap']);
+
+    if (exitCode != 0) {
+      throw new Error(`Failed to bootstrap the build script. Exit code: ${exitCode}`);
+    }
+  }
+
   private static async resolveCakeToolPath(workingDirectory?: ToolsDirectory): Promise<string> {
     return workingDirectory
       ? workingDirectory.append(dotnetCake)

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ export async function run() {
     const scriptPath = core.getInput('script-path');
     const version = core.getInput('cake-version');
     const target = new CakeArgument('target', core.getInput('target'));
+    const cakeBootstrap = (core.getInput('cake-bootstrap') || '').toLowerCase() === 'true';
 
     const toolsDir = new ToolsDirectory();
     toolsDir.create();
@@ -16,6 +17,11 @@ export async function run() {
     DotNet.disableTelemetry();
 
     await DotNet.installLocalCakeTool(toolsDir, version);
+
+    if (cakeBootstrap) {
+      await CakeTool.bootstrapScript(scriptPath, toolsDir);
+    }
+
     await CakeTool.runScript(scriptPath, toolsDir, target);
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
This PR proposes an fix for #3, allowing task to bootstrap Cake scripts, so modules can be used with this action.